### PR TITLE
Deserialize timestamps as chrono DateTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,13 @@ version = "0.1.0"
 error-chain = "0.10"
 futures = "0.1"
 hyper = "0.11"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+chrono = { version = "0.4", optional = true, features = ["serde"] }
+
+[features]
+default = ["chrono"]
 
 [dev-dependencies]
 tokio-core = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ extern crate futures;
 extern crate serde;
 extern crate serde_json;
 
+#[cfg(feature = "chrono")]
+extern crate chrono;
+
 pub mod model;
 mod client;
 pub mod error;

--- a/src/model.rs
+++ b/src/model.rs
@@ -292,7 +292,12 @@ mod ts_seconds_opt {
     where
         S: Serializer,
     {
-        Option::<DateTime>::serialize(&dt, serializer)
+        #[cfg(feature = "chrono")]
+        {
+            Option::<DateTimeSeconds>::serialize(&dt.map(DateTimeSeconds), serializer)
+        }
+
+        #[cfg(not(feature = "chrono"))] Option::<DateTime>::serialize(&dt, serializer)
     }
 }
 


### PR DESCRIPTION
Add optional `chrono` feature to have timestamps deserialized as
`DateTime<Utc>` instead of seconds